### PR TITLE
Updated CMakeLists to be cross-platform and use vcpkg instead of NuGet for dependencies 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
 *.rptproj.bak
+
+# Ignore the boostrap tools directory
+bootstrap/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,47 @@
-# CMAKE file for EDGITOR by Alepacho
+# CMAKE file for EDGITOR by Alepacho and keithcodes
 
 cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include(FindPkgConfig)
+# Check if we should use vcpkg from the boostrap script
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/bootstrap/vcpkg")
+	if (DEFINED ENV{VCPKG_ROOT})
+		message(WARNING "Overriding system-wide VCPKG_ROOT value with boostrap folder's vcpkg install")
+	endif()
+
+	set(ENV{VCPKG_ROOT} "${CMAKE_CURRENT_LIST_DIR}/bootstrap/vcpkg")
+endif()
+
+# Checks if vcpkg is installed, and if so sets the cmake toolchain file to the one provided by vcpkg
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+	set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
+	message(STATUS "Using vcpkg CMake toolchain at ${CMAKE_TOOLCHAIN_FILE}")
+elseif(NOT DEFINED ENV{VCPKG_ROOT})
+	message(WARNING "VCPKG_ROOT env variable not set, can't automatically determine vcpkg CMake toolchain file. You can ignore this if you're not using vcpkg for project libraries.")
+	message(WARNING "Either set the system environment variable VCPKG_ROOT to your vcpkg installation directory, or add the -DCMAKE_TOOLCHAIN_FILE=/my/vcpkg/dir variable to the CMake profile.")
+endif()
+
+# Check if vcpkg is enabled and sets the appropriate platform triplet
+if (DEFINED ENV{VCPKG_ROOT} AND DEFINED CMAKE_TOOLCHAIN_FILE)
+	if (NOT DEFINED VCPKG_TARGET_TRIPLET)
+		if (WIN32)
+			if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+				# Uses static libraries with debug symbols
+				set(VCPKG_TARGET_TRIPLET "x64-windows-static-md" CACHE STRING "")
+			else()
+				# Uses static libraries
+				set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "")
+			endif()
+		elseif(UNIX)
+			set(VCPKG_TARGET_TRIPLET "x64-linux" CACHE STRING "")
+		else()
+			message(ERROR "Failed to determine appropriate VCPKG_TARGET_TRIPLET value for your platform, please set the VCPKG_TARGET_TRIPLET environment variables")
+		endif()
+	endif()
+
+	message(STATUS "Using vcpkg triplet toolchain ${VCPKG_TARGET_TRIPLET}")
+endif()
 
 project(EDGITOR)
 
@@ -21,70 +58,24 @@ elseif(MSVC)
 	target_compile_options(${PROJECT_NAME} PRIVATE /W4 /permissive-)
 endif()
 
-if(APPLE)
-	set(CMAKE_FIND_FRAMEWORK ONLY)
-	find_library(SDL2_LIBRARY SDL2)
-	find_library(SDL2_TTF_LIBRARY SDL2_ttf)
-	find_library(SDL2_IMAGE_LIBRARY SDL2_image)
+# Find the system OpenGL library
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${OPENGL_LIBRARIES})
 
-	target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARY} ${SDL2_TTF_LIBRARY} ${SDL2_IMAGE_LIBRARY})
-elseif(WIN32)
-	message("RESOURCE_PATH: " ${RESOURCE_PATH})
+# Find the SDL2 library from vcpkg
+find_package(SDL2 CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2main SDL2::SDL2-static)
 
-	find_program(NUGET nuget)
-	if(NOT NUGET)
-		message(FATAL "CMake could not find the nuget command line tool. Please install it!")
-	else()
-		set(SDL_VER "2.0.12")
-		set(SDL_ttf_VER "2.0.15")
-		set(SDL_image_VER "2.0.5")
-		
-		set(SDL2_LIB_PATH "${CMAKE_BINARY_DIR}/packages/sdl2.nuget.${SDL_VER}/build/native/lib/x64/dynamic")
-		set(SDL2_ttf_LIB_PATH "${CMAKE_BINARY_DIR}/packages/sdl2_ttf.nuget.${SDL_ttf_VER}/build/native/lib/x64/dynamic")
-		set(SDL2_image_LIB_PATH "${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.${SDL_image_VER}/build/native/lib/x64/dynamic")
-		
-		configure_file(packages.config packages.config COPYONLY)
-		
-		execute_process(COMMAND 
-			${NUGET} restore packages.config -SolutionDirectory ${CMAKE_BINARY_DIR}
-			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-		)
+# Find the SDL2-image library from vcpkg
+find_package(sdl2-image CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2_image)
 
-		include_directories(${PROJECT_NAME} "${CMAKE_BINARY_DIR}/packages/sdl2.nuget.${SDL_VER}/build/native/include")
-		include_directories(${PROJECT_NAME} "${CMAKE_BINARY_DIR}/packages/sdl2_ttf.nuget.${SDL_ttf_VER}/build/native/include")
-		include_directories(${PROJECT_NAME} "${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.${SDL_image_VER}/build/native/include")
-		
-		target_link_libraries(${PROJECT_NAME}
-			"${SDL2_LIB_PATH}/SDL2.lib"
-			"${SDL2_LIB_PATH}/SDL2main.lib"
-			"${SDL2_ttf_LIB_PATH}/SDL2_ttf.lib"
-			"${SDL2_image_LIB_PATH}/SDL2_image.lib"
-			"glu32.lib;opengl32.lib;")
-		
-		file(RENAME "${PROJECT_SOURCE_DIR}/resources/" "${CMAKE_CURRENT_BINARY_DIR}/resources/")
-		
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2.nuget.redist.${SDL_VER}/build/native/bin/x64/dynamic/SDL2.dll"
-			"${CMAKE_BINARY_DIR}/Debug/SDL2.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_ttf.nuget.redist.${SDL_ttf_VER}/build/native/bin/x64/dynamic/SDL2_ttf.dll"
-			"${CMAKE_BINARY_DIR}/Debug/SDL2_ttf.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_ttf.nuget.redist.${SDL_ttf_VER}/build/native/bin/x64/dynamic/libfreetype-6.dll"
-			"${CMAKE_BINARY_DIR}/Debug/libfreetype-6.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_ttf.nuget.redist.${SDL_ttf_VER}/build/native/bin/x64/dynamic/zlib1.dll"
-			"${CMAKE_BINARY_DIR}/Debug/zlib1.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.redist.${SDL_image_VER}/build/native/bin/x64/dynamic/SDL2_image.dll"
-			"${CMAKE_BINARY_DIR}/Debug/SDL2_image.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.redist.${SDL_image_VER}/build/native/bin/x64/dynamic/libjpeg-9.dll"
-			"${CMAKE_BINARY_DIR}/Debug/libjpeg-9.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.redist.${SDL_image_VER}/build/native/bin/x64/dynamic/libpng16-16.dll"
-			"${CMAKE_BINARY_DIR}/Debug/libpng16-16.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.redist.${SDL_image_VER}/build/native/bin/x64/dynamic/libtiff-5.dll"
-			"${CMAKE_BINARY_DIR}/Debug/libtiff-5.dll" COPYONLY)
-		configure_file("${CMAKE_BINARY_DIR}/packages/sdl2_image.nuget.redist.${SDL_image_VER}/build/native/bin/x64/dynamic/libwebp-7.dll"
-			"${CMAKE_BINARY_DIR}/Debug/libwebp-7.dll" COPYONLY)
-	endif()
-elseif(PKG_CONFIG_FOUND)
-	pkg_check_modules(SDL2 REQUIRED sdl2 SDL2_ttf SDL2_image)
-	include_directories(${PROJECT_NAME} ${SDL2_INCLUDE_DIRS})
-	target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES})
-endif()
+# Find the SDL2-ttf library from vcpkg
+find_package(sdl2-ttf CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2_ttf)
 
+# Copy the resources folder into the build directory
+add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+		${CMAKE_SOURCE_DIR}/resources/ $<TARGET_FILE_DIR:${PROJECT_NAME}>/resources/)

--- a/README.md
+++ b/README.md
@@ -27,21 +27,110 @@ EDGITOR is now open source, and I'd love for this to grow via the community! Fee
 Now you can use Cmake!
 
 ## BUILD INSTRUCTIONS
-### Windows
-- Install Visual Studio 2019 and Cmake
-- [Download Nuget.exe Here](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe), and place it in `C:\Program Files\CMake\bin`
-- Open Command Prompt, and go to EDGITOR's folder: `cd *EDGITOR_FOLDER_LOCATION*`
-- Then execute this command `cmake -B build -G "Visual Studio 16 2019"`
-- Open VS19 and set EDGITOR as StartUp Project
 
-### macOS
-- Install Xcode and Cmake
-- Install SDL and SDL_ttf frameworks manually
-- Run following command in Terminal `cmake -B build -G Xcode`
+### Dependencies
 
-### Linux
-- Make sure you have your compiler of choice, Cmake and pkg-config installed
-- Install SDL and SDL_ttf
-- Run `cmake -B build .`
-- `cd` in the `build` directory and run `make`
+EDGITOR requires the following libraries (instructions on how to install are provided below):
+
+  * SDL2
+  * SDL2_image
+  * SDL2_ttf
+
+##### Windows
+
+On Windows you'll need to following dependencies for building EDGITOR:
+  * Git
+  * Visual Studio 2015 Update 3 or newer
+  * Cmake
+  
+##### MacOS
+
+On MacOS you'll need to following dependencies for building EDGITOR:
+  * Xcode
+  * Git
+  * Cmake
+
+##### Linux
+
+On Linux you'll need to following dependencies for building EDGITOR:
+  * GCC (or an equivalent Cmake support C++ compiler like clang)
+  * Git
+  * Cmake
+
+#### Installing Dependencies
+
+EDGITOR uses vcpkg for managing it's dependencies with optimal cross-platform support.
+
+To get started you'll need to either manually install vcpkg and set the VCPKG_ROOT environment variable to your vcpkg root, or run the bootstrap.bat/sh file in the root of the repository.
+
+##### Installing vcpkg automatically
+
+The repository contains a bootstrap script in the root that can be used to automatically fetch the necessary tools and dependencies for the project.
+
+What the boostrap script does:
+  * Creates a `/boostrap` directory in the repo
+  * Clones or pulls (updates) vcpkg in `/boostrap/vcpkg`
+  * Runs the vcpkg boostrap script to compile or update vcpkg
+  * Installs the necessary project dependencies
+
+To run the bootstrap script, open a command line or Powershell to the repository directory and run:
+```
+./bootstrap.bat
+```
+
+This may take 10-15 minutes on the first run as it installs vcpkg and then builds the dependencies. 
+
+> If you want to pull the latest version of vcpkg or any of the libraries, just re-run the bootstrap script and it'll update the vcpkg install.
+
+##### Installing vcpkg manually
+
+First you'll need to clone the vcpkg repository somewhere on your machine (I use `C:\bin\` for files like this - Keith).
+```
+git clone https://github.com/microsoft/vcpkg
+``` 
+
+Next you'll need to run vcpkg's bootstrap script which will build and initialize vcpkg.
+```
+.\vcpkg\bootstrap-vcpkg.bat
+```
+
+Now you should add the vcpkg directory to your system `PATH` so you can run the `vcpkg` command without needing to be in the vcpkg directory. You also need to set the `VCPKG_ROOT` system or user environment variable to the vcpkg installation directory.  
+
+Now you can install all the dependencies with the dependencies script:
+
+**Windows**
+```
+dependencies.bat
+```
+
+**Linux**
+```
+dependencies.sh
+```
+
+### Building
+
+#### Windows
+
+First you'll need to generate the Visual Studio project with cmake:
+```
+cmake -B build -G "Visual Studio 16 2019"
+```
+
+Now you can open the EDGITOR folder as a Visual Studio project and set `EDGITOR` as StartUp Project.
+
+#### macOS
+
+You can build the EDGITOR project using Xcode via cmake:
+```
+cmake -B build -G Xcode
+```
+
+#### Linux
+
+```
+cmake -B build .
+cd build
+make
+```
 

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,0 +1,53 @@
+@echo off
+
+REM Check if we need to create the bootstrap directory
+IF EXIST "./bootstrap" (
+    echo Found existing bootstrap directory
+) ELSE (
+    echo Creating the bootstrap directory
+    mkdir bootstrap
+)
+
+REM Change to the boostrap directory
+cd bootstrap
+
+REM Check if vcpkg is already clones to the bootstrap directory
+IF EXIST "./vcpkg" (
+    echo Found existing vcpkg installation
+    echo Checking for vcpkg update
+    cd vcpkg
+
+    REM Pull the repo to check for updates
+    git pull
+) ELSE (
+    echo Cloning vcpkg
+
+    REM Clone the repo into the bootstrap directory
+    git clone https://github.com/microsoft/vcpkg vcpkg
+    cd vcpkg
+)
+
+REM Run the vcpkg bootstrap script to ensure it's up to date
+echo Ensuring vcpkg is update to date
+call bootstrap-vcpkg.bat
+
+REM Add vcpkg command to the local path
+SET PATH=%PATH%;%CD%
+REM Set the vcpkg root to the boostrap directory for the rest of the script
+set VCPKG_ROOT=%CD%
+
+REM Move back to the boostrap directory
+cd ..
+
+REM Move back to the repository directory
+cd ..
+
+
+REM Install the vcpkg dependencies
+echo Installing vcpkg dependencies
+
+call dependencies.bat
+
+echo Done installing packages!
+
+echo Finished bootstraping project!

--- a/dependencies.bat
+++ b/dependencies.bat
@@ -1,0 +1,7 @@
+
+REM x64-windows-static-md triplets are required for debug builds and x64-windows-static for release
+REM I'm not entirely certain why, this is just what I found from testing on various personal projects. - Keith
+echo Using VCPKG_ROOT from %VCPKG_ROOT%
+vcpkg install sdl2:x64-windows-static-md sdl2:x64-windows-static
+vcpkg install sdl2-image:x64-windows-static-md sdl2-image:x64-windows-static
+vcpkg install sdl2-ttf:x64-windows-static-md sdl2-ttf:x64-windows-static

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,0 +1,4 @@
+
+vcpkg install sdl2
+vcpkg install sdl2-image
+vcpkg install sdl2-ttf


### PR DESCRIPTION
I updated the CMakeList and added some helper functions so that the project uses vcpkg instead of NuGet for dependencies so dependencies can be uniformly handled across platforms. I also removed most of the unnecessary platform-specific CMake commands.