### PR TITLE
Added Github Actions workflow for automatically building releases for commits and tags 

### DIFF
--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: Linux is having download errors and Mac is outright failing to find SDL2_image
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
         include:
           - os: windows-latest
             triplet: x64-windows-static

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -106,7 +106,7 @@ jobs:
       # Uploads the zip as a build artifact
       - uses: actions/upload-artifact@v2
         with:
-          name: build-${{ matrix.triplet }}
+          name: edgitor-${{ matrix.triplet }}
           path: release/
       # Creates and uploads a release if the push is tagged
       - name: Create Release
@@ -131,5 +131,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: EDGITOR.zip
-          asset_name: EDGITOR-'${{ matrix.triplet }}'.zip
+          asset_name: EDGITOR-'${{ matrix.triplet }}'-${{ github.ref }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -14,21 +14,31 @@ jobs:
             triplet: x64-windows
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
             vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+            osDependenciesCommand: |
+              choco install ninja
+              choco install git.install --params "/GitAndUnixToolsOnPath"
           - os: ubuntu-latest
             triplet: x64-linux
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
             vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+            osDependenciesCommand: |
+              sudo apt-get install ninja-build -y
+              sudo apt-get install xorg-dev
+              sudo apt-get install freeglut3-dev
           - os: macos-latest
             triplet: x64-osx
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
             vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+            osDependenciesCommand: brew install ninja
 
     steps:
       # Checkout the git repository
       - uses: actions/checkout@v1
         with:
           submodules: true
-
+      # Install system dependencies
+      - name: install dependencies
+        run: '${{ matrix.osDependenciesCommand }}'
       - uses: lukka/get-cmake@latest
       - name: dir
         run: find $RUNNER_WORKSPACE

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -25,6 +25,7 @@ jobs:
               sudo apt-get install ninja-build -y
               sudo apt-get install xorg-dev
               sudo apt-get install freeglut3-dev
+              sudo apt-get install libmesa-dev
           - os: macos-latest
             triplet: x64-osx
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -25,7 +25,7 @@ jobs:
               sudo apt-get install ninja-build -y
               sudo apt-get install xorg-dev
               sudo apt-get install freeglut3-dev
-              sudo apt-get install libgl1-mesa-dev
+              sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
           - os: macos-latest
             triplet: x64-osx
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -92,7 +92,41 @@ jobs:
           vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
           buildDirectory: '${{ runner.workspace }}/b/ninja-bash/'
           useShell: bash
+      # Collects all project binary and resources into a single folder
       - name: Install with CMake
         run: |
           mkdir release
           cmake --install ${{ runner.workspace }}/b/ninja/ --prefix ./release
+      - name: Compress build
+          run: |
+            zip -r EDGITOR.zip ./release
+      # Uploads the zip as a build artifact
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: EDGITOR.zip
+      # Creates and uploads a release if the push is tagged
+      - name: Create Release
+        # Only run if push is tagged
+        if: startsWith(github.ref, 'refs/tags/')
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        # Only run if push is tagged
+        if: startsWith(github.ref, 'refs/tags/')
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: EDGITOR.zip
+          asset_name: EDGITOR-'${{ matrix.triplet }}'.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -98,8 +98,8 @@ jobs:
           mkdir release
           cmake --install ${{ runner.workspace }}/b/ninja/ --prefix ./release
       - name: Compress build
-          run: |
-            zip -r EDGITOR.zip ./release
+        run: |
+          zip -r EDGITOR.zip ./release
       # Uploads the zip as a build artifact
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -95,4 +95,4 @@ jobs:
       - name: Install with CMake
         run: |
           mkdir release
-          cmake --prefix ./release --install
+          cmake --install ${{ runner.workspace }}/b/ninja/ --prefix ./release

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
-            triplet: x64-windows
+            triplet: x64-windows-static
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
             vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
             osDependenciesCommand: |
@@ -106,7 +106,7 @@ jobs:
       # Uploads the zip as a build artifact
       - uses: actions/upload-artifact@v2
         with:
-          name: build
+          name: build-${{ matrix.triplet }}
           path: EDGITOR.zip
       # Creates and uploads a release if the push is tagged
       - name: Create Release

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -98,8 +98,10 @@ jobs:
           mkdir release
           cmake --install ${{ runner.workspace }}/b/ninja/ --prefix ./release
       - name: Compress build
-        run: |
-          zip -r EDGITOR.zip ./release
+        uses: papeloto/action-zip@v1
+        with:
+          files: release/
+          dest: EDGITOR.zip
       # Uploads the zip as a build artifact
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: build-${{ matrix.triplet }}
-          path: EDGITOR.zip
+          path: release/
       # Creates and uploads a release if the push is tagged
       - name: Create Release
         # Only run if push is tagged

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -1,0 +1,83 @@
+name: build_vcpkg
+on: [push]
+
+jobs:
+  job:
+    name: ${{ matrix.os }}-build_vcpkg
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            triplet: x64-windows
+            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
+            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+          - os: ubuntu-latest
+            triplet: x64-linux
+            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
+            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+          - os: macos-latest
+            triplet: x64-osx
+            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
+            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+
+    steps:
+      # Checkout the git repository
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: lukka/get-cmake@latest
+      - name: dir
+        run: find $RUNNER_WORKSPACE
+        shell: bash
+      # Install the vcpkg packages
+      - name: Restore artifacts, or run vcpkg, build and cache artifacts
+        uses: lukka/run-vcpkg@v3
+        id: runvcpkg
+        with:
+          vcpkgArguments: '${{ matrix.vcpkgPackages }}'
+          vcpkgTriplet: '${{ matrix.triplet }}'
+          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+          vcpkgGitCommitId: '${{ matrix.vcpkgCommitId }}'
+      - name: dir
+        run: find $RUNNER_WORKSPACE
+        shell: bash
+      - name: Prints outputs of run-vcpkg task
+        run: echo "'${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}' '${{  steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}' "
+      - name: Run CMake+Ninja without triplet
+        uses: lukka/run-cmake@v2
+        id: runcmake
+        with:
+          cmakeGenerator: 'Ninja'
+          cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
+          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+          useVcpkgToolchainFile: true
+          buildWithCMakeArgs: '-- -v'
+          buildDirectory: '${{ runner.workspace }}/b/ninja/'
+      - name: Run CMake+Ninja with triplet (cmd)
+        uses: lukka/run-cmake@v2
+        id: runcmake_cmd
+        with:
+          cmakeGenerator: 'Ninja'
+          cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
+          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+          useVcpkgToolchainFile: true
+          buildWithCMakeArgs: '-- -v'
+          vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
+          buildDirectory: '${{ runner.workspace }}/b/ninja/'
+      - name: Run CMake+Ninja with triplet (bash)
+        if: false
+        uses: lukka/run-cmake@v2
+        id: runcmake_bash
+        with:
+          cmakeGenerator: 'Ninja'
+          cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
+          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+          useVcpkgToolchainFile: true
+          buildWithCMakeArgs: '-- -v'
+          vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
+          buildDirectory: '${{ runner.workspace }}/b/ninja-bash/'
+          useShell: bash

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -25,7 +25,7 @@ jobs:
               sudo apt-get install ninja-build -y
               sudo apt-get install xorg-dev
               sudo apt-get install freeglut3-dev
-              sudo apt-get install libmesa-dev
+              sudo apt-get install libgl1-mesa-dev
           - os: macos-latest
             triplet: x64-osx
             vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -17,20 +17,21 @@ jobs:
             osDependenciesCommand: |
               choco install ninja
               choco install git.install --params "/GitAndUnixToolsOnPath"
-          - os: ubuntu-latest
-            triplet: x64-linux
-            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
-            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
-            osDependenciesCommand: |
-              sudo apt-get install ninja-build -y
-              sudo apt-get install xorg-dev
-              sudo apt-get install freeglut3-dev
-              sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
-          - os: macos-latest
-            triplet: x64-osx
-            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
-            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
-            osDependenciesCommand: brew install ninja
+          # TODO: Linux is having download errors and Mac is outright failing to find SDL2_image
+#          - os: ubuntu-latest
+#            triplet: x64-linux
+#            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
+#            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+#            osDependenciesCommand: |
+#              sudo apt-get install ninja-build -y
+#              sudo apt-get install xorg-dev
+#              sudo apt-get install freeglut3-dev
+#              sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
+#          - os: macos-latest
+#            triplet: x64-osx
+#            vcpkgCommitId: '8a9a97315aefb3f8bc5d81bf66ca0025938b9c91'
+#            vcpkgPackages: 'sdl2 sdl2-image sdl2-ttf'
+#            osDependenciesCommand: brew install ninja
 
     steps:
       # Checkout the git repository

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -59,16 +59,6 @@ jobs:
         shell: bash
       - name: Prints outputs of run-vcpkg task
         run: echo "'${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}' '${{  steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}' "
-      - name: Run CMake+Ninja without triplet
-        uses: lukka/run-cmake@v2
-        id: runcmake
-        with:
-          cmakeGenerator: 'Ninja'
-          cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
-          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
-          useVcpkgToolchainFile: true
-          buildWithCMakeArgs: '-- -v'
-          buildDirectory: '${{ runner.workspace }}/b/ninja/'
       - name: Run CMake+Ninja with triplet (cmd)
         uses: lukka/run-cmake@v2
         id: runcmake_cmd
@@ -80,19 +70,6 @@ jobs:
           buildWithCMakeArgs: '-- -v'
           vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
           buildDirectory: '${{ runner.workspace }}/b/ninja/'
-      - name: Run CMake+Ninja with triplet (bash)
-        if: false
-        uses: lukka/run-cmake@v2
-        id: runcmake_bash
-        with:
-          cmakeGenerator: 'Ninja'
-          cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
-          cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
-          useVcpkgToolchainFile: true
-          buildWithCMakeArgs: '-- -v'
-          vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
-          buildDirectory: '${{ runner.workspace }}/b/ninja-bash/'
-          useShell: bash
       # Collects all project binary and resources into a single folder
       - name: Install with CMake
         run: |

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -93,6 +93,6 @@ jobs:
           buildDirectory: '${{ runner.workspace }}/b/ninja-bash/'
           useShell: bash
       - name: Install with CMake
-          run: |
-            mkdir release
-            cmake --prefix ./release --install
+        run: |
+          mkdir release
+          cmake --prefix ./release --install

--- a/.github/workflows/build_vcpkg.yml
+++ b/.github/workflows/build_vcpkg.yml
@@ -39,6 +39,7 @@ jobs:
       # Install system dependencies
       - name: install dependencies
         run: '${{ matrix.osDependenciesCommand }}'
+      # Fetch the cmake executable
       - uses: lukka/get-cmake@latest
       - name: dir
         run: find $RUNNER_WORKSPACE
@@ -91,3 +92,7 @@ jobs:
           vcpkgTriplet: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_TRIPLET_OUT }}
           buildDirectory: '${{ runner.workspace }}/b/ninja-bash/'
           useShell: bash
+      - name: Install with CMake
+          run: |
+            mkdir release
+            cmake --prefix ./release --install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ file(GLOB SOURCE
 add_executable(${PROJECT_NAME} ${SOURCE})
 
 if(UNIX)
-	target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra)
+	target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -lstdc++fs)
 elseif(MSVC)
 	target_compile_options(${PROJECT_NAME} PRIVATE /W4 /permissive-)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,3 +79,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2_ttf)
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_directory
 		${CMAKE_SOURCE_DIR}/resources/ $<TARGET_FILE_DIR:${PROJECT_NAME}>/resources/)
+
+# Copies the exe and resources to the install directory when an install is ran
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION .)


### PR DESCRIPTION
Added a workflow file for Github actions that will automatically build EDGITOR for Windows and upload it as a commit artifact. Linux and Mac are included, Linux should run but Mac was having issues finding SDL2_image and Linux was seemingly having issues due to one of the SDL2 download servers being down (need to try again in a couple days).

Additionally, if a tagged release is pushed then the workflow will automatically upload the build to the releases page on Github.